### PR TITLE
Downgraded framework

### DIFF
--- a/MCQuery/MCQuery.csproj
+++ b/MCQuery/MCQuery.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>MCQuery.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>

--- a/MCQuery/MCServer.cs
+++ b/MCQuery/MCServer.cs
@@ -165,9 +165,11 @@ namespace MCQuery
                     // Address Length
                     data.WriteByte((byte)Encoding.ASCII.GetByteCount(Address));
                     // Server address
-                    data.Write(Encoding.ASCII.GetBytes(Address));
+                    var addressBytes = Encoding.ASCII.GetBytes(Address);
+                    data.Write(addressBytes, 0, addressBytes.Length);
                     // Server port
-                    data.Write(BitConverter.GetBytes((ushort)Port));
+                    var portBytes = BitConverter.GetBytes((ushort)Port);
+                    data.Write(portBytes, 0, portBytes.Length);
                     // State command
                     Utilities.WriteVarInt(data, state);
                 }
@@ -199,7 +201,7 @@ namespace MCQuery
                     // Convert that into long bytes
                     pingBytes = BitConverter.GetBytes(ticks);
                     // Write long into data stream
-                    data.Write(pingBytes);
+                    data.Write(pingBytes, 0, pingBytes.Length);
                 }
                 // Write packet length (including packet ID)
                 Utilities.WriteVarInt(packet, (int)data.Length + 1);
@@ -243,7 +245,7 @@ namespace MCQuery
 
                 // Parse the received ping bytes
                 byte[] pongBytes = new byte[Math.Max(8, packetLength - 1)];
-                network.Read(pongBytes);
+                network.Read(pongBytes, 0, pongBytes.Length);
                 // Stop stopwatch, no need to measure from this point onwards
                 stopwatch.Stop();
                 ping = stopwatch.Elapsed.TotalMilliseconds;

--- a/MCQueryTests/MCQueryTests.csproj
+++ b/MCQueryTests/MCQueryTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/MCQueryTests/ServerStatus.cs
+++ b/MCQueryTests/ServerStatus.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+﻿using Newtonsoft.Json;
 
 namespace MCQueryTests
 {
@@ -6,28 +6,28 @@ namespace MCQueryTests
     {
         // Don't care about description, this changes over different server
 
-        [JsonPropertyName("players")]
+        [JsonProperty("players")]
         public Players Players { get; set; }
 
-        [JsonPropertyName("version")]
+        [JsonProperty("version")]
         public Version Version { get; set; }
     }
 
     internal class Players
     {
-        [JsonPropertyName("max")]
+        [JsonProperty("max")]
         public long Max { get; set; }
 
-        [JsonPropertyName("online")]
+        [JsonProperty("online")]
         public long Online { get; set; }
     }
 
     internal class Version
     {
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; }
 
-        [JsonPropertyName("protocol")]
+        [JsonProperty("protocol")]
         public long Protocol { get; set; }
     }
 }

--- a/MCQueryTests/UtilitiesTest.cs
+++ b/MCQueryTests/UtilitiesTest.cs
@@ -1,9 +1,9 @@
 using MCQuery;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 
 namespace MCQueryTests
 {
@@ -64,7 +64,7 @@ namespace MCQueryTests
             }
             // Don't catch JsonException, test will detect this throw
             // Parse to expected minimal server status
-            _ = JsonSerializer.Deserialize<ServerStatus>(response);
+            _ = JsonConvert.DeserializeObject<ServerStatus>(response);
         }
 
         [TestMethod]


### PR DESCRIPTION
As per #2, the main project is downgraded to .NET Standard 2.0 to support more (older) projects and expand usage across projects. This will cost in terms of performance as .NET's JSON implementation is faster than Newtonsoft's but this can be overlooked.

Closes #2 