### PR TITLE
Fixing CS7034 error

### DIFF
--- a/MCQuery/MCQuery.csproj
+++ b/MCQuery/MCQuery.csproj
@@ -19,6 +19,8 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <Deterministic>False</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MCQueryTests/UtilitiesTest.cs
+++ b/MCQueryTests/UtilitiesTest.cs
@@ -40,7 +40,7 @@ namespace MCQueryTests
         public void PingTest()
         {
             // Note: make a better test with TcpListener and some fake handshake to test this method
-            var address = "mc.hypixel.net";
+            var address = "hub.mc-complex.com";
             var port = 25565;
             var server = new MCServer(address, port);
             var ping = server.Ping();
@@ -54,7 +54,7 @@ namespace MCQueryTests
         public void StatusTest()
         {
             // Note: make a better test with TcpListener and some fake handshake to test this method
-            var address = "mc.hypixel.net";
+            var address = "hub.mc-complex.com";
             var port = 25565;
             var server = new MCServer(address, port);
             var response = server.Status();


### PR DESCRIPTION
Appveyor had been failing with error `CS7034`
> The specified version string does not conform to the required format - major[.minor[.build[.revision]]] [C:\projects\mcquery\MCQuery\MCQuery.csproj]

Based on this [answer on stackoverflow](https://stackoverflow.com/a/55573656/11913463) it should be fixed. (When building locally I wasn't getting the error)